### PR TITLE
remove duplicate header

### DIFF
--- a/yes.c
+++ b/yes.c
@@ -10,7 +10,6 @@
 #include <linux/slab.h>
 #include <linux/device.h>
 #include <linux/miscdevice.h>
-#include <linux/miscdevice.h>
 #include <linux/file.h>
 
 #include <asm/uaccess.h>


### PR DESCRIPTION
It looks `miscdevice.h` is included twice.